### PR TITLE
Add proper nonce handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ export default defineNuxtConfig({
 ##### Configuration options
 
 ```ts
-type ConfigOptions {
+type PluginArgs {
  containerId: string;
  containerUrl: string;
  dataLayerName?: string;
- nonce?: string;
+ cspNonceBridge?: boolean;
 }
 ```
 
@@ -52,7 +52,21 @@ type ConfigOptions {
 
 The nonce attribute is useful to allow-list specific elements, such as a particular inline script or style elements. It can help you to avoid using the CSP unsafe-inline directive, which would allow-list all inline scripts or styles.
 
-If you want your nonce to be passed to the script, pass it as the third argument when calling the script initialization method.
+This package provides an option, `cspNonceBridge`, that lets it retrieve the `nonce` attribute provided by plugins such as `nuxt-security` and apply it to the container.
+
+Example config:
+
+```ts
+// nuxt.config.ts
+export default defineNuxtConfig({
+  modules: ["nuxt-security", "@piwikpro/nuxt-piwik-pro"],
+  piwikPro: {
+    containerId: process.env.PIWIK_PRO_CONTAINER_ID!,
+    containerUrl: process.env.PIWIK_PRO_CONTAINER_URL!,
+    cspNonceBridge: true,
+  },
+});
+```
 
 #### Usage
 
@@ -177,6 +191,7 @@ Please explore the `./example` directory to get to know how to use this package 
 - [PaymentInformation](#paymentinformation)
 - [PiwikPROHandler](#piwikprohandler)
 - [PiwikPROServicesType](#piwikproservicestype)
+- [PluginArgs](#pluginargs)
 - [Product](#product)
 - [VisitorInfo](#visitorinfo)
 
@@ -291,6 +306,12 @@ ___
 
 ___
 
+#### PluginArgs
+
+Ƭ **PluginArgs**: \{ `containerId`: `string` ; `containerUrl`: `string` ; `cspNonceBridge?`: `boolean`  } & [`InitOptions`](#initoptions)
+
+___
+
 #### Product
 
 Ƭ **Product**: `Object`
@@ -330,7 +351,7 @@ ___
 | Name | Type |
 | :------ | :------ |
 | `this` | `void` |
-| `inlineOptions` | `PluginArgs` |
+| `inlineOptions` | [`PluginArgs`](#pluginargs) |
 | `nuxt` | `Nuxt` |
 
 ##### Returns

--- a/docs/README_BASE.md
+++ b/docs/README_BASE.md
@@ -36,11 +36,11 @@ export default defineNuxtConfig({
 #### Configuration options
 
 ```ts
-type ConfigOptions {
+type PluginArgs {
  containerId: string;
  containerUrl: string;
  dataLayerName?: string;
- nonce?: string;
+ cspNonceBridge?: boolean;
 }
 ```
 
@@ -48,7 +48,21 @@ type ConfigOptions {
 
 The nonce attribute is useful to allow-list specific elements, such as a particular inline script or style elements. It can help you to avoid using the CSP unsafe-inline directive, which would allow-list all inline scripts or styles.
 
-If you want your nonce to be passed to the script, pass it as the third argument when calling the script initialization method.
+This package provides an option, `cspNonceBridge`, that lets it retrieve the `nonce` attribute provided by plugins such as `nuxt-security` and apply it to the container.
+
+Example config:
+
+```ts
+// nuxt.config.ts
+export default defineNuxtConfig({
+  modules: ["nuxt-security", "@piwikpro/nuxt-piwik-pro"],
+  piwikPro: {
+    containerId: process.env.PIWIK_PRO_CONTAINER_ID!,
+    containerUrl: process.env.PIWIK_PRO_CONTAINER_URL!,
+    cspNonceBridge: true,
+  },
+});
+```
 
 ### Usage
 

--- a/example/nuxt.config.ts
+++ b/example/nuxt.config.ts
@@ -23,7 +23,6 @@ export default defineNuxtConfig({
         containerUrl:
           process.env.PIWIK_PRO_CONTAINER_URL ||
           "0a0b8661-8c10-4d59-e8fg-1h926ijkl184",
-        nonce: process.env.PIWIK_PRO_NONCE,
         dataLayerName: process.env.PIWIK_PRO_DATA_LAYER_NAME,
       },
     ],

--- a/src/composables/index.ts
+++ b/src/composables/index.ts
@@ -19,7 +19,7 @@ const handlePiwikPRO = async <T = unknown>(
     );
   } else {
     console.warn(
-      "Piwik PRO is client only library and cannot be use in server side."
+      "Piwik PRO is a client only library and cannot be use in server side."
     );
   }
   return undefined;

--- a/src/composables/index.ts
+++ b/src/composables/index.ts
@@ -19,7 +19,7 @@ const handlePiwikPRO = async <T = unknown>(
     );
   } else {
     console.warn(
-      "Piwik PRO is a client only library and cannot be use in server side."
+      "Piwik PRO is a client only library and cannot be used in server side."
     );
   }
   return undefined;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,1 @@
+export const PIWIK_PRO_NONCE_STATE_KEY = "piwik-pro-csp-nonce";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export * from "@piwikpro/vue-piwik-pro";
 export { default as PiwikPRO } from "@piwikpro/vue-piwik-pro";
-export { PiwikPROServicesType, PiwikPROHandler } from "./types";
+export { PiwikPROServicesType, PiwikPROHandler, PluginArgs } from "./types";
 export { default } from "./module";

--- a/src/module/index.ts
+++ b/src/module/index.ts
@@ -1,4 +1,5 @@
-import { addPlugin, defineNuxtModule } from "nuxt/kit";
+import "../schema";
+import { addPlugin, defineNuxtModule, useLogger } from "nuxt/kit";
 import { dirname, resolve } from "path";
 import { fileURLToPath } from "url";
 import { PluginArgs } from "../types";
@@ -15,10 +16,32 @@ export default defineNuxtModule<PluginArgs>({
       );
     }
 
+    const { nonce, cspNonceBridge, ...publicOptions } = options;
+
+    if (nonce !== undefined) {
+      useLogger("piwik-pro").warn(
+        "The `nonce` module option is ignored: it cannot be a proper per-response CSP nonce when set in config. Use a per-request nonce (for example via nuxt-security) and enable `cspNonceBridge: true`. See module documentation."
+      );
+    }
+
     nuxt.options.runtimeConfig.public = {
       ...nuxt.options.runtimeConfig.public,
-      ...options,
+      ...publicOptions,
+      piwikProCspNonceBridge: Boolean(cspNonceBridge),
     };
+
+    if (cspNonceBridge) {
+      addPlugin({
+        src: resolve(
+          dirname(fileURLToPath(import.meta.url)),
+          "..",
+          "plugin",
+          "nonce-bridge"
+        ),
+        name: "piwik-pro-nonce-bridge",
+      });
+    }
+
     addPlugin({
       src: resolve(dirname(fileURLToPath(import.meta.url)), "..", "plugin"),
       mode: "client",

--- a/src/module/index.ts
+++ b/src/module/index.ts
@@ -16,11 +16,11 @@ export default defineNuxtModule<PluginArgs>({
       );
     }
 
-    const { nonce, cspNonceBridge, ...publicOptions } = options;
+    const { cspNonceBridge, nonce, ...publicOptions } = options;
 
     if (nonce !== undefined) {
       useLogger("piwik-pro").warn(
-        "The `nonce` module option is ignored: it cannot be a proper per-response CSP nonce when set in config. Use a per-request nonce (for example via nuxt-security) and enable `cspNonceBridge: true`. See module documentation."
+        "The `nonce` module option is not safe for CSP when set in static config: the same value is sent to every visitor and does not rotate per response. Prefer a per-request nonce (for example via nuxt-security) and `cspNonceBridge: true`."
       );
     }
 

--- a/src/module/index.ts
+++ b/src/module/index.ts
@@ -16,9 +16,9 @@ export default defineNuxtModule<PluginArgs>({
       );
     }
 
-    const { cspNonceBridge, nonce, ...publicOptions } = options;
+    const { cspNonceBridge, ...publicOptions } = options;
 
-    if (nonce !== undefined) {
+    if (publicOptions.nonce !== undefined) {
       useLogger("piwik-pro").warn(
         "The `nonce` module option is not safe for CSP when set in static config: the same value is sent to every visitor and does not rotate per response. Prefer a per-request nonce (for example via nuxt-security) and `cspNonceBridge: true`."
       );

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -1,8 +1,14 @@
-import { defineNuxtPlugin, useRuntimeConfig } from "nuxt/app";
+import type { InitOptions } from "@piwikpro/vue-piwik-pro";
+import { defineNuxtPlugin, useRuntimeConfig, useState } from "nuxt/app";
 import PiwikPRO from "@piwikpro/tracking-base-library";
 import * as PiwikPROServices from "@piwikpro/vue-piwik-pro";
+import { PIWIK_PRO_NONCE_STATE_KEY } from "../constants";
 import { PluginArgs, PiwikPROServicesType } from "../types";
 import { VERSION } from "../version";
+
+type PublicPiwikConfig = Omit<PluginArgs, "nonce" | "cspNonceBridge"> & {
+  piwikProCspNonceBridge?: boolean;
+};
 
 export default defineNuxtPlugin<{ piwikPRO: PiwikPROServicesType }>({
   name: "piwik-pro",
@@ -10,15 +16,27 @@ export default defineNuxtPlugin<{ piwikPRO: PiwikPROServicesType }>({
     try {
       if (import.meta.client) {
         const { public: publicConfig } = useRuntimeConfig();
-        const { containerId, containerUrl, ...restOptions } =
-          publicConfig as PluginArgs;
+        const {
+          containerId,
+          containerUrl,
+          piwikProCspNonceBridge,
+          ...restOptions
+        } = publicConfig as PublicPiwikConfig;
+
+        let initOptions: InitOptions = { ...restOptions };
+        if (piwikProCspNonceBridge) {
+          const bridged = useState<string>(PIWIK_PRO_NONCE_STATE_KEY).value;
+          if (bridged) {
+            initOptions = { ...restOptions, nonce: bridged };
+          }
+        }
 
         PiwikPROServices.Miscellaneous.setTrackingSourceProvider(
           "nuxt",
           VERSION
         );
 
-        PiwikPRO.initialize(containerId ?? "", containerUrl ?? "", restOptions);
+        PiwikPRO.initialize(containerId ?? "", containerUrl ?? "", initOptions);
       }
     } catch (err) {
       console.error(err);

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -28,6 +28,12 @@ export default defineNuxtPlugin<{ piwikPRO: PiwikPROServicesType }>({
           const bridged = useState<string>(PIWIK_PRO_NONCE_STATE_KEY).value;
           if (bridged) {
             initOptions = { ...restOptions, nonce: bridged };
+          } else {
+            if (import.meta.dev ?? false) {
+              console.warn(
+                "No nonce found for CSP nonce bridge. nuxt-security or another CSP nonce provider should be used with the cspNonceBridge option."
+              );
+            }
           }
         }
 

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -6,7 +6,7 @@ import { PIWIK_PRO_NONCE_STATE_KEY } from "../constants";
 import { PluginArgs, PiwikPROServicesType } from "../types";
 import { VERSION } from "../version";
 
-type PublicPiwikConfig = Omit<PluginArgs, "nonce" | "cspNonceBridge"> & {
+type PublicPiwikConfig = Omit<PluginArgs, "cspNonceBridge"> & {
   piwikProCspNonceBridge?: boolean;
 };
 

--- a/src/plugin/nonce-bridge.ts
+++ b/src/plugin/nonce-bridge.ts
@@ -1,0 +1,17 @@
+import { defineNuxtPlugin, useRequestEvent, useState } from "nuxt/app";
+import { PIWIK_PRO_NONCE_STATE_KEY } from "../constants";
+
+export default defineNuxtPlugin({
+  name: "piwik-pro-nonce-bridge",
+  enforce: "pre",
+  setup() {
+    useState<string>(PIWIK_PRO_NONCE_STATE_KEY, () => {
+      if (import.meta.server) {
+        const event = useRequestEvent();
+        const n = event?.context?.security?.nonce;
+        return typeof n === "string" ? n : "";
+      }
+      return "";
+    });
+  },
+});

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,8 +1,7 @@
 import type { PluginArgs } from "./types";
 
 declare module "nuxt/schema" {
-  interface PublicRuntimeConfig
-    extends Omit<PluginArgs, "nonce" | "cspNonceBridge"> {
+  interface PublicRuntimeConfig extends Omit<PluginArgs, "cspNonceBridge"> {
     piwikProCspNonceBridge?: boolean;
   }
 }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,0 +1,10 @@
+import type { PluginArgs } from "./types";
+
+declare module "nuxt/schema" {
+  interface PublicRuntimeConfig
+    extends Omit<PluginArgs, "nonce" | "cspNonceBridge"> {
+    piwikProCspNonceBridge?: boolean;
+  }
+}
+
+export {};

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ import { NuxtApp } from "nuxt/schema";
 export type PluginArgs = {
   containerId: string;
   containerUrl: string;
+  cspNonceBridge?: boolean;
 } & InitOptions;
 
 export type PiwikPROServicesType = typeof PiwikPROServices;


### PR DESCRIPTION
Refers to #29 

Adds proper CSP `nonce` handling instead of the current approach that receives the nonce once from the config. The plugin hooks into the request context to retrieve a nonce provided by tools like `nuxt-security`.

## Considerations

It's unclear whether to deprecate the `nonce` config option - on one hand it leads to security false-positives and may mislead CSP checkers due to a nonce technically being set but not being truly unique per request, on the other this would be a breaking change for consumers who rely upon that option.