### PR TITLE
Updated node version in github workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install modules

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install library dependencies


### PR DESCRIPTION
Updated node version used in github workflows v20 -> v24 as v20 has reached its EOL.
This will allow to pass CI run on Dependabot pull requests - as there is a difference between npm versions generated package-lock.json which fails when running npm ci.