### PR TITLE
Added nuxt compatibility check in CI

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -51,3 +51,34 @@ jobs:
             echo "Documentation is not up to date!"
             exit 1
           fi
+
+  # Verify the library is compatible with both Nuxt 3 and Nuxt 4.
+  # Single job: the library is built once, then the example is rebuilt against
+  # each Nuxt major in sequence (overriding the version pinned in example).
+  compatibility-tests:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+
+      - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+
+      # Build the library once (dist/ is consumed by the example install)
+      - name: Install library dependencies
+        run: npm ci
+
+      - name: Run library build
+        run: npm run build
+
+      # `npm install nuxt@<major>` (not `npm ci`) so it overrides the version
+      # pinned in example/package-lock.json. node_modules is wiped between legs
+      # to keep each Nuxt major isolated.
+      - name: Example on Nuxt 3
+        run: cd example && rm -rf node_modules && npm install nuxt@^3 && npm run build && npm run test
+
+      - name: Example on Nuxt 4
+        run: cd example && rm -rf node_modules && npm install nuxt@^4 && npm run build && npm run test


### PR DESCRIPTION
### Added nuxt compatibility check in CI

Before updating nuxt to v4 in root directory - let's add a CI check that will make sure that we still support both v3 and v4 versions as they are still being in development.